### PR TITLE
reimplement binary visitor

### DIFF
--- a/hydrogen/TableStore.cs
+++ b/hydrogen/TableStore.cs
@@ -15,7 +15,6 @@ namespace Hydrogen
         private List<TableStoreListener> listeners = new List<TableStoreListener>();
         private int current = 0;
         private BinarySearchTree<int> ns;
-        private ArraySegment<(int fieldId, Variant v)> changes = new (int fieldId, Variant v)[256];
         public TableStore(Dictionary<FieldSpec, FieldHolder> fieldSpecToFieldHolder,
             Dictionary<IField, FieldHolder> fieldToFieldHolder,
             BinarySearchTree<int> rs)

--- a/hydrogen/Utils.cs
+++ b/hydrogen/Utils.cs
@@ -31,5 +31,54 @@ namespace Hydrogen
                 return r;
             };
         }
+
+        public static Func<IEnumerable<T>, IEnumerable<T>, IEnumerable<T>> Union<T>(IComparer<T> comparer)
+        {
+            IEnumerable<T> Calc(IEnumerable<T> l, IEnumerable<T> r, IComparer<T> comparer)
+            {
+                var le = l.GetEnumerator();
+                var re = r.GetEnumerator();
+
+                var lf = le.MoveNext();
+                var rf = re.MoveNext();
+                while (lf && rf)
+                {
+                    var lv = le.Current;
+                    var rv = re.Current;
+
+                    var b = comparer.Compare(lv, rv);
+                    if (b < 0)
+                    {
+                        yield return lv;
+                        lf = le.MoveNext();
+                    }
+                    else if (b > 0)
+                    {
+                        yield return rv;
+                        rf = re.MoveNext();
+                    }
+                    else
+                    {
+                        yield return lv;
+                        lf = le.MoveNext();
+                        rf = re.MoveNext();
+                    }
+                }
+
+                while (lf)
+                {
+                    yield return le.Current;
+                    lf = le.MoveNext();
+                }
+
+                while (rf)
+                {
+                    yield return re.Current;
+                    rf = re.MoveNext();
+                }
+            }
+
+            return (x, y) => Calc(x, y, comparer);
+        }
     }
 }


### PR DESCRIPTION
1. BinaryVisitor now handles And in a more efficient way, instead of doing 2 filters on the same joinable then intersecting them, And now does the first filtering then does the second filtering based on the first filtering result.
2. Or is adjusted accordingly.